### PR TITLE
Fix not found docs link to valid link

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,4 @@ public class Test {
 
 ```
 
-### 더 자세한 정보는 [Docs](https://docs.bootpay.co.kr/api/validate?languageCurrentIndex=1)를 참조해주세요. 
+### 더 자세한 정보는 [Docs](https://docs.bootpay.co.kr/rest/verify)를 참조해주세요. 


### PR DESCRIPTION
When click the Docs link, responses with 404 not found.
I think tihs url is deprecated.
Replace wrong link to valid link.

![image](https://user-images.githubusercontent.com/14071105/95012117-b94f0700-0670-11eb-8207-4b85adb8c96c.png)

Wrong link: https://docs.bootpay.co.kr/api/validate?languageCurrentIndex=1
Valid link: https://docs.bootpay.co.kr/rest/verify

See also
  - https://docs.bootpay.co.kr/rest/verify